### PR TITLE
Update alpha version to include two tildes. Do not dput to pre-stable in make-release script

### DIFF
--- a/bump-version.py
+++ b/bump-version.py
@@ -35,7 +35,7 @@ from hidpidaemon.tests.helpers import TempDir
 
 
 DISTROS = ('trusty', 'xenial', 'yakkety', 'zesty', 'artful', 'bionic')
-ALPHA = '~alpha'
+ALPHA = '~~alpha'
 
 TREE = path.dirname(path.abspath(__file__))
 assert TREE == sys.path[0]

--- a/make-release.py
+++ b/make-release.py
@@ -35,8 +35,7 @@ from hidpidaemon.tests.helpers import TempDir
 
 
 DISTROS = ('trusty', 'xenial', 'yakkety', 'zesty', 'artful', 'bionic')
-PPA = 'ppa:system76-dev/pre-stable'
-ALPHA = '~alpha'
+ALPHA = '~~alpha'
 
 TREE = path.dirname(path.abspath(__file__))
 assert TREE == sys.path[0]
@@ -44,15 +43,12 @@ assert os.getcwd() == TREE
 
 CHANGELOG = path.join(TREE, 'debian', 'changelog')
 SETUP = path.join(TREE, 'setup.py')
+INIT = path.join(TREE, 'hidpidaemon', '__init__.py')
 DSC_NAME =     'hidpi-daemon_{}.dsc'.format(__version__)
-CHANGES_NAME = 'hidpi-daemon_{}_source.changes'.format(__version__)
-PARENT = path.dirname(TREE)
-DSC = path.join(PARENT, DSC_NAME)
-CHANGES = path.join(PARENT, CHANGES_NAME)
 
 assert path.isfile(CHANGELOG)
 assert path.isfile(SETUP)
-assert path.isfile(path.join(TREE, 'hidpidaemon', '__init__.py'))
+assert path.isfile(INIT)
 
 
 def confirm():
@@ -109,7 +105,7 @@ def parse_version_line(line):
     if ALPHA not in line:
         raise ValueError('Missing {!r} in version:\n{!r}'.format(ALPHA, line))
     m = re.match(
-        '^hidpi-daemon \(([\.0-9]+)~alpha\) ([a-z]+); urgency=low$', line
+        '^hidpi-daemon \(([\.0-9]+)' + ALPHA + '\) ([a-z]+); urgency=low$', line
     )
     if m is None:
         raise ValueError('bad version line[0]:\n{!r}'.format(line))
@@ -126,7 +122,7 @@ def parse_version_line(line):
 
 def build_version_line(line):
     parse_version_line(line)
-    return line.replace('~alpha', '')
+    return line.replace(ALPHA, '')
 
 
 def build_author_line():
@@ -193,26 +189,11 @@ print('Will release {!r} for {!r}'.format(version, distro))
 if not confirm():
     abort()
 
-# Make sure DSC and CHANGES file for this version don't arleady exist:
-for filename in (DSC, CHANGES):
-    if path.isfile(filename):
-        abort('Already exists: {!r}'.format(filename))
-
 # Commit and tag:
 check_call(['git', 'commit', CHANGELOG, '-m', 'Release {}'.format(version)])
 check_call(['git', 'push'])
 check_call(['git', 'tag', version])
 check_call(['git', 'push', 'origin', 'tag', version])
-
-# Build source package:
-check_call(['gbp', 'buildpackage', '--git-ignore-branch', '-S'])
-
-# Confirm before we dput to PPA:
-print('-' * 80)
-print('Changes file is {!r}'.format(CHANGES))
-print('Will upload to {!r}'.format(PPA))
-if confirm():
-    check_call(['dput', PPA, CHANGES])
 
 # We're done:
 print('-' * 80)


### PR DESCRIPTION
This will make the maint scripts more compatible with the build system