### PR TITLE
Update hidpidaemon2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+hidpi-daemon (18.04.7) bionic; urgency=low
+
+  * Update hidpidaemon2.py file to set gi require version
+  * Add newer models with HiDPI displays
+  * Update Maintainer
+
+ -- Aaron Honeycutt <aaron@system76.com>  Tue, 02 Jun 2020 09:18:29 -0600
+
 hidpi-daemon (18.04.6~~alpha) bionic; urgency=low
 
   * Daily WIP for 18.04.6

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,14 +1,9 @@
-hidpi-daemon (18.04.7) bionic; urgency=low
-
-  * Update hidpidaemon2.py file to set gi require version
-  * Add newer models with HiDPI displays
-  * Update Maintainer
-
- -- Aaron Honeycutt <aaron@system76.com>  Tue, 02 Jun 2020 09:18:29 -0600
-
 hidpi-daemon (18.04.6~~alpha) bionic; urgency=low
 
   * Daily WIP for 18.04.6
+  * Update hidpidaemon2.py file to set gi require version
+  * Add newer models with HiDPI displays
+  * Update Maintainer
 
  -- Jeremy Soller <jeremy@system76.com>  Thu, 13 Feb 2020 13:14:42 -0700
 

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: hidpi-daemon
 Section: x11
 Priority: optional
-Maintainer: David Jordan <david2@system76.com>
+Maintainer: Aaron Honeycutt <aaron@system76.com>
 Build-Depends: debhelper (>= 9), 
     dh-python, 
     dh-systemd,

--- a/hidpi-daemon
+++ b/hidpi-daemon
@@ -29,6 +29,7 @@ import argparse
 import os
 import sys
 import logging
+import gi
 
 gi.require_version('Gtk', '3.0')
 

--- a/hidpidaemon/hidpidaemon2.py
+++ b/hidpidaemon/hidpidaemon2.py
@@ -31,6 +31,8 @@ import logging
 import time
 import os
 
+gi.require_version('Gtk', '3.0')
+
 from gi.repository import Gio, GObject, GLib, Gtk
 from pydbus import SessionBus
 from pydbus.publication import Publication
@@ -49,6 +51,8 @@ from hidpidaemon import monitorsxml
 log = logging.getLogger(__name__)
 
 NEEDS_HIDPI_AUTOSCALING = (
+    'addw1',
+    'addw2',
     'bonw12',
     'galp2',
     'galp3',
@@ -56,13 +60,17 @@ NEEDS_HIDPI_AUTOSCALING = (
     'oryp3-ess',
     'oryp3',
     'serw10',
+    'serw11'
 )
 
 NVIDIA = {
+    'addw1',
+    'addw2',
     'bonw12',
     'oryp2-ess',
     'oryp3-ess',
     'serw10',
+    'serw11'
 }
 
 INTEL = {

--- a/hidpidaemon/hidpidaemon2.py
+++ b/hidpidaemon/hidpidaemon2.py
@@ -30,6 +30,7 @@ from Xlib.ext import randr
 import logging
 import time
 import os
+import gi
 
 gi.require_version('Gtk', '3.0')
 


### PR DESCRIPTION
This updates the following files:
- hidpidamon/hidpidaemon2.py
- debian/control
- debian/changelog

It corrects the following issues:
- an error message in logs that the gi version is not set in the hidpidaemon2.py file
- updates the d/control file to a new maintainer (this can be changed if needed)
