### PR TITLE
Check if running in NVIDIA graphics mode

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 hidpi-daemon (18.04.7~~alpha) bionic; urgency=low
 
   * Daily WIP for 18.04.7
+  * Fixed running in hybrid graphics mode
 
  -- Tim Crawford <tcrawford@system76.com>  Fri, 02 Sep 2022 10:26:20 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+hidpi-daemon (18.04.7~~alpha) bionic; urgency=low
+
+  * Daily WIP for 18.04.7
+
+ -- Tim Crawford <tcrawford@system76.com>  Fri, 02 Sep 2022 10:26:20 -0600
+
 hidpi-daemon (18.04.6) bionic; urgency=low
 
   * Update hidpidaemon2.py file to set gi require version

--- a/hidpidaemon/__init__.py
+++ b/hidpidaemon/__init__.py
@@ -25,7 +25,7 @@ from os import path
 import logging
 
 
-__version__ = '18.04.6'
+__version__ = '18.04.7'
 
 datadir = path.join(path.dirname(path.abspath(__file__)), 'data')
 log = logging.getLogger(__name__)

--- a/hidpidaemon/hidpidaemon2.py
+++ b/hidpidaemon/hidpidaemon2.py
@@ -191,10 +191,21 @@ class HiDPIAutoscaling:
 
         self.displays_xml = self.get_displays_xml()
 
-    #Test for nvidia proprietary driver and nvidia-settings
+    # Check which GPU is used for rendering the desktop
     def get_gpu_vendor(self):
         if self.model in INTEL:
             return 'intel'
+
+        # Check for system76-power/gpu-manager written file first
+        try:
+            with open('/etc/prime-discrete') as mode:
+                if mode.read().strip() == 'on':
+                    return 'nvidia'
+                return 'intel'
+        except:
+            pass
+
+        # Fall back to checking loaded modules
         with open('/proc/modules', 'r') as modules:
             if 'nvidia ' in modules.read() and which('nvidia-settings') is not None:
                 return 'nvidia'

--- a/hidpidaemon/hidpidaemon2.py
+++ b/hidpidaemon/hidpidaemon2.py
@@ -195,10 +195,9 @@ class HiDPIAutoscaling:
     def get_gpu_vendor(self):
         if self.model in INTEL:
             return 'intel'
-        modules = open('/proc/modules', 'r')
-        if 'nvidia ' in modules.read() and which('nvidia-settings') is not None:
-            return 'nvidia'
-        else:
+        with open('/proc/modules', 'r') as modules:
+            if 'nvidia ' in modules.read() and which('nvidia-settings') is not None:
+                return 'nvidia'
             return 'intel'
 
     def add_output_mode(self):
@@ -1046,10 +1045,9 @@ class HiDPIAutoscaling:
                     return True # No lids found: System may not be a laptop.
                 else:
                     lid_file_path = os.path.join('/', 'proc', 'acpi', 'button', 'lid', lid_dirs[0], 'state')
-            lid_file = open(lid_file_path, 'r')
-            if 'open' in lid_file.read():
-                return True
-            else:
+            with open(lid_file_path, 'r') as lid_file:
+                if 'open' in lid_file.read():
+                    return True
                 return False
         except:
             return True


### PR DESCRIPTION
Just checking for the proprietary drivers is no longer sufficient, as they will be loaded in hybrid graphics mode but not be used for rendering the desktop.

Rely on the `/etc/prime-discrete` file written by system76-power and gpu-manager to check which rendering mode is being used, falling back to checking the modules if it doesn't exist.