### PR TITLE
Fix fallback to alternate subdirectories in get_internal_lid_state

### DIFF
--- a/hidpidaemon/hidpidaemon2.py
+++ b/hidpidaemon/hidpidaemon2.py
@@ -1038,14 +1038,15 @@ class HiDPIAutoscaling:
 
     def get_internal_lid_state(self):
         try:
-            lid_file_path = '/proc/acpi/button/lid/LID0/state'
-            if os.path.isfile(lid_file_path):
-                lids_path = '/proc/acpi/button/lid/'
-                lid_dirs = [d for d in os.listdir(lids_path) if os.path.isdir(os.path.join(lids_path, d))]
+            lids_path = '/proc/acpi/button/lid/'
+            lid_file_path = os.path.join(lids_path, 'LID0', 'state')
+            if not os.path.isfile(lid_file_path):
+                # Default LID0 not found. Look for another subdirectory with a state file.
+                lid_dirs = [d for d in os.listdir(lids_path) if os.path.isfile(os.path.join(lids_path, d, 'state'))]
                 if len(lid_dirs) < 1:
                     return True # No lids found: System may not be a laptop.
                 else:
-                    lid_file_path = os.path.join('/', 'proc', 'acpi', 'button', 'lid', lid_dirs[0], 'state')
+                    lid_file_path = os.path.join(lids_path, lid_dirs[0], 'state')
             lid_file = open(lid_file_path, 'r')
             if 'open' in lid_file.read():
                 return True


### PR DESCRIPTION
Small bug fix to get_internal_lid_state, adding the "not" in line 1042.
The old version still worked if the default /LID0 subdir exists, but didn't fall back to my /LID.

Also skip over directories that don't have a 'state' file, and a small refactoring to make sure the /proc/acpi/button/lid path only appears once.
